### PR TITLE
Use include_bytes! instead of include_str!

### DIFF
--- a/src/macro_function.rs
+++ b/src/macro_function.rs
@@ -14,7 +14,7 @@ pub(crate) fn macro_fn(input: IncludeFileMacroInput, always_serve: bool) -> Toke
     for (file, path) in file_list.iter().zip(path_list.iter()) {
         let filestr = file.to_str().unwrap().to_string();
         let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
-        if !always_serve && max_file_size != 0 && file_size < max_file_size {
+        if !always_serve && (max_file_size == 0 || file_size < max_file_size) {
             let mime = detect_mime(file);
             output = quote! {
                 #output

--- a/src/macro_function.rs
+++ b/src/macro_function.rs
@@ -18,7 +18,7 @@ pub(crate) fn macro_fn(input: IncludeFileMacroInput, always_serve: bool) -> Toke
             let mime = detect_mime(file);
             output = quote! {
                 #output
-                #ident.at(#path).get(|_| async { Ok(tide::Response::builder(200).content_type(#mime).body(include_str!(concat!("../", #filestr)))) });
+                #ident.at(#path).get(|_| async { Ok(tide::Response::builder(200).content_type(#mime).body(&include_bytes!(concat!("../", #filestr))[..])) });
             };
         } else {
             output = quote! {


### PR DESCRIPTION
`include_str!` checks if the file is correct utf8, but binary files are not. This should allow binary files to be included as well.

Perfect crate otherwise, thank you! :)

Edit: I have also made `auto_serve_dir!` embed files regardless of their max file size if not specified. 